### PR TITLE
ci: source Pulumi secrets from env vars (no secrets in any file)

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -37,15 +37,6 @@ jobs:
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       # The repo secret is named PULUMI_TOKEN; the Pulumi CLI reads PULUMI_ACCESS_TOKEN.
       PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_TOKEN }}
-      # Bot secrets — injected at runtime from GitHub secrets (never committed to any file). index.js
-      # reads these via process.env; optional YOUTUBE_* are skipped when their secret is unset.
-      DISCORD_API_TOKEN: ${{ secrets.DISCORD_API_TOKEN }}
-      DISCORD_APPLICATION_ID: ${{ secrets.DISCORD_APPLICATION_ID }}
-      DISCORD_PUBLIC_KEY: ${{ secrets.DISCORD_PUBLIC_KEY }}
-      YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
-      YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
-      YOUTUBE_REFRESH_TOKEN: ${{ secrets.YOUTUBE_REFRESH_TOKEN }}
-      YOUTUBE_STREAM_ID: ${{ secrets.YOUTUBE_STREAM_ID }}
     steps:
       - uses: actions/checkout@v4
 
@@ -73,6 +64,16 @@ jobs:
 
       - name: 'Pulumi up'
         working-directory: infra
+        env:
+          # Bot secrets — scoped to ONLY this step (least privilege), not the whole job. index.js reads
+          # them via process.env; optional YOUTUBE_* are skipped when their secret is unset.
+          DISCORD_API_TOKEN: ${{ secrets.DISCORD_API_TOKEN }}
+          DISCORD_APPLICATION_ID: ${{ secrets.DISCORD_APPLICATION_ID }}
+          DISCORD_PUBLIC_KEY: ${{ secrets.DISCORD_PUBLIC_KEY }}
+          YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
+          YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
+          YOUTUBE_REFRESH_TOKEN: ${{ secrets.YOUTUBE_REFRESH_TOKEN }}
+          YOUTUBE_STREAM_ID: ${{ secrets.YOUTUBE_STREAM_ID }}
         run: |
           pulumi stack select "$PULUMI_STACK"
           pulumi up --yes --skip-preview

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -37,6 +37,15 @@ jobs:
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       # The repo secret is named PULUMI_TOKEN; the Pulumi CLI reads PULUMI_ACCESS_TOKEN.
       PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_TOKEN }}
+      # Bot secrets — injected at runtime from GitHub secrets (never committed to any file). index.js
+      # reads these via process.env; optional YOUTUBE_* are skipped when their secret is unset.
+      DISCORD_API_TOKEN: ${{ secrets.DISCORD_API_TOKEN }}
+      DISCORD_APPLICATION_ID: ${{ secrets.DISCORD_APPLICATION_ID }}
+      DISCORD_PUBLIC_KEY: ${{ secrets.DISCORD_PUBLIC_KEY }}
+      YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
+      YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
+      YOUTUBE_REFRESH_TOKEN: ${{ secrets.YOUTUBE_REFRESH_TOKEN }}
+      YOUTUBE_STREAM_ID: ${{ secrets.YOUTUBE_STREAM_ID }}
     steps:
       - uses: actions/checkout@v4
 

--- a/infra/Pulumi.discord-bot.yaml
+++ b/infra/Pulumi.discord-bot.yaml
@@ -1,7 +1,7 @@
 config:
-  # Non-secret config only. Secrets (Discord/YouTube) are intentionally NOT committed — set them on
-  # the stack with `pulumi config set --secret c3-discord-bot:<key> <value>` when needed. Pulumi writes
-  # them into this file locally (encrypted); do NOT commit those lines. See infra/README.md.
+  # Non-secret config only. Secrets (Discord/YouTube) are NOT stored here at all — index.js reads them
+  # from ENVIRONMENT VARIABLES at deploy time (GitHub secrets in CI, `export` locally). Never add secret
+  # values to this file (don't use `pulumi config set --secret` for them). See infra/README.md.
   #
   # Values below match the defaults referenced in index.js. Stack name is `discord-bot`, so
   # environment == "discord-bot" and derived names carry that suffix (e.g. ca-c3-discord-bot-discord-bot).

--- a/infra/README.md
+++ b/infra/README.md
@@ -37,24 +37,27 @@ npm install
 
 pulumi stack select discord-bot          # `--create` if it doesn't exist yet
 
-# Secrets are NOT committed — set them on the stack when needed (Pulumi writes them into the local
-# Pulumi.discord-bot.yaml; do NOT commit the secret lines — the file tracks only non-secret config):
-pulumi config set --secret c3-discord-bot:discordApiToken      <token>
-pulumi config set --secret c3-discord-bot:discordApplicationId <id>
-pulumi config set --secret c3-discord-bot:discordPublicKey     <key>
+# Secrets are provided via ENV VARS — never written to any file. Required: Discord; optional: YouTube.
+export DISCORD_API_TOKEN=<token>
+export DISCORD_APPLICATION_ID=<id>
+export DISCORD_PUBLIC_KEY=<key>
 # Optional (YouTube live scheduling):
-pulumi config set --secret c3-discord-bot:youtubeClientId      <id>
-pulumi config set --secret c3-discord-bot:youtubeClientSecret  <secret>
-pulumi config set --secret c3-discord-bot:youtubeRefreshToken  <token>
-pulumi config set --secret c3-discord-bot:youtubeStreamId      <id>
+export YOUTUBE_CLIENT_ID=<id>
+export YOUTUBE_CLIENT_SECRET=<secret>
+export YOUTUBE_REFRESH_TOKEN=<token>
+export YOUTUBE_STREAM_ID=<id>
 
 pulumi up
 ```
 
-Secrets are kept **out of the repo**: `Pulumi.discord-bot.yaml` tracks only non-secret config. The
-Discord/YouTube secrets are set directly on the stack with `pulumi config set --secret ...` when needed
-and are **never committed**. Because they live in the stack config (not Pulumi Cloud), `pulumi up` —
-locally or in CI — requires them to be configured in that environment first.
+Secrets are kept **out of every file**: `index.js` reads them from environment variables (wrapped as
+Pulumi secrets), so nothing sensitive is written to `Pulumi.discord-bot.yaml` or anywhere in the repo.
+- **CI:** [`infra.yml`](../.github/workflows/infra.yml) injects them into the `pulumi up` step from
+  **GitHub secrets** (on the `PROD` environment): `DISCORD_API_TOKEN`, `DISCORD_APPLICATION_ID`,
+  `DISCORD_PUBLIC_KEY` (required) and `YOUTUBE_*` (optional).
+- **Local:** `export` them before `pulumi up` (as above).
+
+Only **non-secret** config (region, names, channel IDs, image) lives in `Pulumi.discord-bot.yaml`.
 
 ## CI/CD
 

--- a/infra/index.js
+++ b/infra/index.js
@@ -45,20 +45,26 @@ const leetcodeForumId = cfg.get("leetcodeForumId") || "1188947130505769031";
 const communityEventsChannelId = cfg.require("communityEventsChannelId");
 const sayHiChannel = cfg.require("sayHiChannel");
 
-// Required secrets — `pulumi up` fails clearly if any is unset (see Pulumi.discord-bot.yaml).
-const discordApiToken = cfg.requireSecret("discordApiToken");
-const discordApplicationId = cfg.requireSecret("discordApplicationId");
-const discordPublicKey = cfg.requireSecret("discordPublicKey");
+// Secrets come from ENVIRONMENT VARIABLES — never from committed config/files. In CI they're injected
+// from GitHub secrets on the `pulumi up` step; locally, `export` them before `pulumi up`. Wrapped in
+// pulumi.secret so they're also encrypted in Pulumi state.
+const requireEnv = (name) => {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing required env var ${name} — set it (GitHub secret in CI, or 'export' locally) before running 'pulumi up'.`);
+  return v;
+};
+const discordApiToken = pulumi.secret(requireEnv("DISCORD_API_TOKEN"));
+const discordApplicationId = pulumi.secret(requireEnv("DISCORD_APPLICATION_ID"));
+const discordPublicKey = pulumi.secret(requireEnv("DISCORD_PUBLIC_KEY"));
 
-// Optional YouTube secrets — only wired in when the config key is set: `getSecret` returns undefined
-// when the key is absent, and we drop those. (Don't set a key to an empty string — an empty Container
-// App secret fails to provision.) Same guard as myfeed.
+// Optional YouTube secrets — only wired in when the env var is set (non-empty). The bot degrades
+// gracefully when absent.
 const youtubeSecrets = [
-  { secretName: "youtube-client-id",     env: "YOUTUBE_CLIENT_ID",     value: cfg.getSecret("youtubeClientId") },
-  { secretName: "youtube-client-secret", env: "YOUTUBE_CLIENT_SECRET", value: cfg.getSecret("youtubeClientSecret") },
-  { secretName: "youtube-refresh-token", env: "YOUTUBE_REFRESH_TOKEN", value: cfg.getSecret("youtubeRefreshToken") },
-  { secretName: "youtube-stream-id",     env: "YOUTUBE_STREAM_ID",     value: cfg.getSecret("youtubeStreamId") },
-].filter((s) => s.value !== undefined);
+  { secretName: "youtube-client-id",     env: "YOUTUBE_CLIENT_ID",     value: process.env.YOUTUBE_CLIENT_ID },
+  { secretName: "youtube-client-secret", env: "YOUTUBE_CLIENT_SECRET", value: process.env.YOUTUBE_CLIENT_SECRET },
+  { secretName: "youtube-refresh-token", env: "YOUTUBE_REFRESH_TOKEN", value: process.env.YOUTUBE_REFRESH_TOKEN },
+  { secretName: "youtube-stream-id",     env: "YOUTUBE_STREAM_ID",     value: process.env.YOUTUBE_STREAM_ID },
+].filter((s) => s.value).map((s) => ({ secretName: s.secretName, env: s.env, value: pulumi.secret(s.value) }));
 
 const tags = { project: projectName, environment, managedBy: "pulumi" };
 const namePrefix = `${projectName}-${environment}`;


### PR DESCRIPTION
## What

Move the Discord/YouTube secrets out of **every** file — not even encrypted in `Pulumi.discord-bot.yaml`. `index.js` now reads them from **environment variables** (wrapped as `pulumi.secret`); `infra.yml` injects them into `pulumi up` from **GitHub secrets**; locally you `export` them.

## Why

`pulumi config set --secret` writes the (encrypted) value into `Pulumi.<stack>.yaml`. Even encrypted, that's secret material in a repo-tracked file. Env-vars keep secrets in **no file at all**.

## Changes
- **`infra/index.js`** — `requireEnv()` helper; Discord secrets from `process.env.*` (required, clear error if missing), YouTube from `process.env.*` (optional), all `pulumi.secret`-wrapped.
- **`.github/workflows/infra.yml`** — inject `DISCORD_*` / `YOUTUBE_*` into the `pulumi up` step from GitHub secrets (PROD environment).
- **`infra/README.md`** — documents the env-var flow (CI = GitHub secrets, local = `export`).
- Non-secret config (region, names, channel IDs, image) stays in `Pulumi.discord-bot.yaml`.

## Before this works — add GitHub secrets (on the `PROD` environment)
**Required:** `DISCORD_API_TOKEN`, `DISCORD_APPLICATION_ID`, `DISCORD_PUBLIC_KEY`
**Optional:** `YOUTUBE_CLIENT_ID`, `YOUTUBE_CLIENT_SECRET`, `YOUTUBE_REFRESH_TOKEN`, `YOUTUBE_STREAM_ID`

Then run the **Infra** workflow (or `export …` + `pulumi up` locally) to apply. The YouTube secrets appear in the Container App after that `pulumi up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sR2HHQJpVhnQUvozZWdFL
