### PR TITLE
feat(youtube): classify scheduled lives as Education instead of Entertainment

### DIFF
--- a/docs/features/YouTubeLiveScheduling.md
+++ b/docs/features/YouTubeLiveScheduling.md
@@ -171,6 +171,7 @@ YOUTUBE_STREAM_ID=YOUR_REUSABLE_YOUTUBE_STREAM_ID
 ## Behavior Details
 
 - New YouTube lives are created as `public`
+- New YouTube lives are classified under the **Education** category (id `27`) instead of the default **Entertainment** (id `24`). Because `liveBroadcasts.insert` has no category field, the bot applies the category to the underlying video with `videos.update` right after the broadcast is created and bound
 - The event banner image is uploaded as the YouTube thumbnail when available
 - The saved `recording_link` may temporarily point to the scheduled YouTube watch page before the event happens
 - If the YouTube environment variables are missing, the bot logs the problem and skips YouTube scheduling without breaking Discord event creation

--- a/src/usescases/community_events/youtube_live_service.py
+++ b/src/usescases/community_events/youtube_live_service.py
@@ -26,6 +26,10 @@ class YouTubeLiveService:
     SCOPES = ['https://www.googleapis.com/auth/youtube']
     TOKEN_URI = 'https://oauth2.googleapis.com/token'
     GLOBAL_TAGS = ['CraftCodeClub', 'AI', 'ComputerScience', 'Coding', 'Development']
+    # YouTube video category "Education". Without an explicit category the video defaults to
+    # "Entertainment" (id 24). liveBroadcasts.insert has no category field, so this is applied
+    # to the underlying video resource with videos.update after the broadcast is created.
+    EDUCATION_CATEGORY_ID = '27'
 
     def __init__(self) -> None:
         self.__live_streaming_disabled = False
@@ -198,6 +202,10 @@ class YouTubeLiveService:
                 id = broadcast_id,
                 streamId = stream_id).execute()
 
+            # The broadcast id is also the video id. liveBroadcasts.insert cannot set a category,
+            # so classify the video as "Education" on the underlying video resource.
+            self.__set_video_category(youtube, broadcast_id)
+
             if banner_image:
                 self.__upload_thumbnail(youtube, broadcast_id, banner_image)
 
@@ -248,6 +256,44 @@ class YouTubeLiveService:
             logger.warning(f'[SERVICES][YOUTUBE] Failed to upload thumbnail for broadcast Id "{broadcast_id}": {error}')
         except Exception:
             logger.warning(f'[SERVICES][YOUTUBE] Failed to upload thumbnail for broadcast Id "{broadcast_id}"', exc_info = True)
+
+    def __set_video_category(self, youtube, video_id: str) -> None:
+        try:
+            response = youtube.videos().list(
+                part = 'snippet',
+                id = video_id,
+                maxResults = 1).execute()
+
+            items = response.get('items', [])
+            if not items:
+                logger.warning(
+                    f'[SERVICES][YOUTUBE] Video "{video_id}" not found while setting category. Skipping category update.')
+                return
+
+            existing_snippet = items[0].get('snippet', {})
+
+            # videos.update replaces the whole snippet and requires title + categoryId, so preserve
+            # the existing snippet fields and override only the category to avoid wiping metadata.
+            snippet = {
+                'title': existing_snippet.get('title', ''),
+                'categoryId': self.EDUCATION_CATEGORY_ID,
+            }
+            for field in ['description', 'tags', 'defaultLanguage']:
+                if field in existing_snippet and existing_snippet[field] is not None:
+                    snippet[field] = existing_snippet[field]
+
+            youtube.videos().update(
+                part = 'snippet',
+                body = {
+                    'id': video_id,
+                    'snippet': snippet,
+                }).execute()
+
+            logger.info(f'[SERVICES][YOUTUBE] Set category to "Education" (Id {self.EDUCATION_CATEGORY_ID}) for video "{video_id}"')
+        except HttpError as error:
+            logger.warning(f'[SERVICES][YOUTUBE] Failed to set category for video "{video_id}": {error}')
+        except Exception:
+            logger.warning(f'[SERVICES][YOUTUBE] Failed to set category for video "{video_id}"', exc_info = True)
 
     def __build_client(self):
         credentials = Credentials(


### PR DESCRIPTION
## O que muda

As lives agendadas pelo bot passam a ser cadastradas na categoria **Education (27)** em vez do padrão **Entertainment (24)**.

## Por que em dois passos (insert + update)

`liveBroadcasts.insert` **não** aceita `categoryId` no snippet — a categoria pertence ao recurso *video*, não ao *liveBroadcast*. Por isso a categoria é aplicada depois, com `videos.update` (`part=snippet`), no vídeo cujo id é o próprio broadcast id (logo após o `bind`).

Como `videos.update` **substitui o snippet inteiro** e exige `snippet.title` + `snippet.categoryId`, buscamos o snippet atual com `videos.list` e sobrescrevemos apenas o `categoryId`, preservando título/descrição/tags. Falhas nesse passo apenas logam um warning e **não** quebram o agendamento da live.

## Referências — YouTube Data API v3 (para verificar se o código está correto)

- **liveBroadcasts.insert** (o snippet do broadcast não possui campo de categoria):
  https://developers.google.com/youtube/v3/live/docs/liveBroadcasts/insert
- **videos.update** (propriedades obrigatórias no update de snippet: `id`, `snippet.title`, `snippet.categoryId`):
  https://developers.google.com/youtube/v3/docs/videos/update
- **videos.list** (usado para buscar o snippet atual antes do update):
  https://developers.google.com/youtube/v3/docs/videos/list
- **videoCategories.list** (Education = `27`, Entertainment = `24`):
  https://developers.google.com/youtube/v3/docs/videoCategories/list

## Arquivos alterados

- `src/usescases/community_events/youtube_live_service.py` — constante `EDUCATION_CATEGORY_ID = '27'` + método `__set_video_category()` chamado após o `bind`.
- `docs/features/YouTubeLiveScheduling.md` — nota de comportamento sobre a categoria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)