### PR TITLE
chore(security): harden supply-chain protections

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "build"
       include: "scope"
@@ -13,7 +15,9 @@ updates:
   - package-ecosystem: "pip"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "build"
       include: "scope"
@@ -23,7 +27,9 @@ updates:
     directories:
       - "**/*" # To specify manifests in the current directory and recursive subdirectories -> https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "build"
       include: "scope"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.6
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4.37.6
+      uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.6
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -20,16 +20,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Build Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -38,9 +38,9 @@ jobs:
       # The repo secret is named PULUMI_TOKEN; the Pulumi CLI reads PULUMI_ACCESS_TOKEN.
       PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: azure/login@v3
+      - uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
         with:
           creds: |
             {
@@ -50,13 +50,13 @@ jobs:
               "tenantId": "${{ secrets.AZURE_TENANT_ID }}"
             }
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: infra/package-lock.json
 
-      - uses: pulumi/actions@v7
+      - uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7
 
       - name: 'Install IaC deps'
         working-directory: infra

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: 'Checkout'
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: 'Resolve image tag'
       id: tag
@@ -51,7 +51,7 @@ jobs:
         echo "Image tag: ${{ steps.tag.outputs.version }}"
 
     - name: 'Set up Docker Buildx'
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
     - name: Build Docker
       run: |
@@ -62,7 +62,7 @@ jobs:
         docker save -o ${{ env.IMAGE_NAME }}.tar ${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.version }}
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: ${{ env.IMAGE_NAME }}
         path: ${{ env.IMAGE_NAME }}.tar
@@ -79,7 +79,7 @@ jobs:
     steps:
 
     - name: 'Download artifact'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: ${{ env.IMAGE_NAME }}
 
@@ -106,10 +106,10 @@ jobs:
         echo "Image tag: ${{ steps.tag.outputs.version }}"
 
     - name: 'Set up Docker Buildx'
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
     - name: 'Login to Docker Hub'
-      uses: docker/login-action@v4.6.0
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -159,7 +159,7 @@ jobs:
         echo "Deploying image: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.version }}"
 
     - name: 'Login to Azure'
-      uses: azure/login@v3
+      uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
       with:
         creds: |
           {
@@ -172,7 +172,7 @@ jobs:
 
     - name: 'Deploy new revision (Blue-Green)'
       id: containerapp-deploy
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
       with:
         inlineScript: |
           $containerApp = Get-AzContainerApp -Name "${{ env.CONTAINER_APP_NAME }}" -ResourceGroupName "${{ env.RESOURCE_GROUP }}" -SubscriptionId "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
@@ -200,7 +200,7 @@ jobs:
 
     - name: 'Ensure Container App is running'
       id: containerapp-start
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
       with:
         inlineScript: |
           Write-Output "Checking if Container App is running..."
@@ -217,7 +217,7 @@ jobs:
 
     - name: 'Wait for new revision to become healthy'
       id: containerapp-health-check
-      uses: azure/powershell@v3
+      uses: azure/powershell@f5b8adcfff1904872c7b98d4012d4914d74b1a82 # v3
       with:
         inlineScript: |
           Write-Output "Waiting for NEW revision to become healthy..."
@@ -283,7 +283,7 @@ jobs:
 
     - name: 'Azure logout'
       if: always()
-      uses: azure/cli@v3.0.0
+      uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
       with:
         inlineScript: |
           az logout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: "Checkout"
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
         persist-credentials: false


### PR DESCRIPTION
## Summary
- Pin all third-party GitHub Actions to full commit SHA (23 refs across 5 workflows) — tag/branch refs can be re-pointed by a compromised maintainer account, as happened in the tj-actions incident (2025-03). Each pin keeps a `# vX.Y.Z` comment for readability/Dependabot updates.
- Switch Dependabot from daily to weekly schedule.
- Add a 7-day Dependabot cooldown so a malicious release (xz-utils-style) has a detection window before it's proposed for merge.

## Test plan
- [ ] Confirm CI workflows (`codeql-analysis`, `docker-build-test`, `infra`, `publish`, `release`) still run green with pinned SHAs
- [ ] Confirm Dependabot still opens PRs on the new weekly schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)